### PR TITLE
Add support for direct service targets

### DIFF
--- a/templates/mq.yaml
+++ b/templates/mq.yaml
@@ -30,7 +30,11 @@ spec:
       containers:
       - env:
         - name: NETMAKER_SERVER_HOST
+          {{- if .Values.ingress.enabled }}
           value: https://api.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
+          {{- else }}
+          value: 'http://{{ include "netmaker.fullname" . }}-rest.{{ .Release.Namespace }}.{{ .Values.service.kubernetesServiceDomain }}:{{ .Values.service.restPort }}'
+          {{- end }}
         image: eclipse-mosquitto:2.0.11-openssl
         command: ["/mosquitto/config/wait.sh"]
         imagePullPolicy: Always

--- a/templates/netmaker-statefulset.yaml
+++ b/templates/netmaker-statefulset.yaml
@@ -59,11 +59,23 @@ spec:
       {{- end }}
       - env:
         - name: SERVER_NAME
+          {{- if .Values.ingress.enabled }}
           value: broker.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
+          {{- else }}
+          value: {{ include "netmaker.fullname" . }}-mqtt.{{ .Release.Namespace }}.{{ .Values.service.kubernetesServiceDomain }}:8883
+          {{- end }}
         - name: SERVER_API_CONN_STRING
+          {{- if .Values.ingress.enabled }}
           value: api.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}:443
+          {{- else }}
+          value: {{ include "netmaker.fullname" . }}-rest.{{ .Release.Namespace }}.{{ .Values.service.kubernetesServiceDomain }}:{{ .Values.service.restPort }}
+          {{- end }}
         - name: SERVER_HTTP_HOST
+          {{- if .Values.ingress.enabled }}
           value: api.{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}
+          {{- else }}
+          value: {{ include "netmaker.fullname" . }}-rest.{{ .Release.Namespace }}.{{ .Values.service.kubernetesServiceDomain }}:{{ .Values.service.restPort }}
+          {{- end }}
         - name: API_PORT
           value: "8081"
         {{- if not .Values.wireguard.kernel }}

--- a/templates/netmaker-ui-deployment.yaml
+++ b/templates/netmaker-ui-deployment.yaml
@@ -21,5 +21,9 @@ spec:
         - containerPort: {{ .Values.service.uiPort }}
         env:
         - name: BACKEND_URL
+          {{- if .Values.ingress.enabled }}
           value: 'https://{{ .Values.ingress.hostPrefix.rest }}{{ required "A valid .Values.baseDomain entry required!" .Values.baseDomain}}'
+          {{- else }
+          value: 'http://{{ include "netmaker.fullname" . }}-rest.{{ .Release.Namespace }}.{{ .Values.service.kubernetesServiceDomain }}:{{ .Values.service.restPort }}'
+          {{- end }}}
       terminationGracePeriodSeconds: 15

--- a/values.yaml
+++ b/values.yaml
@@ -76,6 +76,7 @@ service:
       port: 80
       # -- the nodeport
       nodePort:
+  kubernetesServiceDomain: 'svc.cluster.local'
 
 ingress:
   # -- attempts to configure ingress if true


### PR DESCRIPTION
Netmaker will work without Ingress in a somewhat restricted mode. When using the dashboard you need to configure the client browser or host.

E.g. `/etc/hosts` file when using `kubectl port-forward` for both dashboard and API:

```
127.0.0.1 netmaker-rest.netmaker.svc.cluster.local
```

Tested only for external clients. Netclient won't work, because no API endpoint is exposed by Ingress.